### PR TITLE
Testing and using tunables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+- 1.3.0 (2020-05-14)
+    * Add testing via 'hspec'.
+
 - 1.2.0 (2016-12-22)
     * Add 'chain' function for working with chains in memory.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # Changelog
 
 - 1.3.0 (2020-05-14)
+    * Add 'chain'' function to use 'chainTunables'
     * Add testing via 'hspec'.
 
 - 1.2.0 (2016-12-22)

--- a/Numeric/MCMC/Metropolis.hs
+++ b/Numeric/MCMC/Metropolis.hs
@@ -87,7 +87,8 @@ drive radial tunable = loop where
     yield next
     loop next prng
 
--- | Return a list of @Chain@ values potentially with tunable values.
+-- | Return a list of @Chain@ values potentially with tunable values computed
+-- from each position.
 chain' ::
      (PrimMonad m, Traversable f)
   => Int

--- a/mighty-metropolis.cabal
+++ b/mighty-metropolis.cabal
@@ -71,3 +71,16 @@ Test-suite bnn
     , mighty-metropolis
     , mwc-probability   >= 1.0.1
 
+Test-suite tests
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test/test
+  main-is:             Spec.hs
+  default-language:    Haskell2010
+  ghc-options:
+    -rtsopts
+  build-depends:
+      base              >= 4 && < 6
+    , containers        >= 0.5 && < 0.6
+    , mighty-metropolis
+    , mwc-probability   >= 1.0.1
+    , hspec

--- a/mighty-metropolis.cabal
+++ b/mighty-metropolis.cabal
@@ -84,3 +84,5 @@ Test-suite tests
     , mighty-metropolis
     , mwc-probability   >= 1.0.1
     , hspec
+    , mwc-random
+    , mcmc-types

--- a/mighty-metropolis.cabal
+++ b/mighty-metropolis.cabal
@@ -1,5 +1,5 @@
 name:                mighty-metropolis
-version:             1.2.0
+version:             1.3.0
 synopsis:            The Metropolis algorithm.
 homepage:            http://github.com/jtobin/mighty-metropolis
 license:             MIT

--- a/test/test/Spec.hs
+++ b/test/test/Spec.hs
@@ -1,0 +1,8 @@
+import Test.Hspec
+
+
+main :: IO ()
+main = hspec $ do
+  describe "Prelude.head" $ do
+    it "returns the first element of a list" $ do
+      head [23 ..] `shouldBe` (23 :: Int)

--- a/test/test/Spec.hs
+++ b/test/test/Spec.hs
@@ -1,8 +1,52 @@
 import Test.Hspec
 
+withinPercent :: Double -> Double -> Double -> Bool
+withinPercent a 0 _ = a == 0
+withinPercent a b n = d / b < (n / 100)
+  where
+    d = abs (a - b)
+
+mean :: [Double] -> Double
+mean xs = sum xs / n
+  where
+    n = fromIntegral (length xs)
+
+variance :: [Double] -> Double
+variance xs = sum [(x - m) ** 2.0 | x <- xs] / (n - 1)
+  where
+    m = mean xs
+    n = fromIntegral (length xs)
+
+stdDev :: [Double] -> Double
+stdDev = sqrt . variance
+
+stdErr :: [Double] -> Double
+stdErr xs = stdDev xs / sqrt n
+  where
+    n = fromIntegral (length xs)
+
+
+testHelperFunctions :: SpecWith ()
+testHelperFunctions = describe "Testing helper functions" $ do
+  it "test withinPercent works" $ do
+    withinPercent 106 100 5 `shouldBe` False
+    withinPercent 105 100 5 `shouldBe` False
+    withinPercent 104 100 5 `shouldBe` True
+    withinPercent 96 100 5 `shouldBe` True
+    withinPercent 95 100 5 `shouldBe` False
+    withinPercent 94 100 5 `shouldBe` False
+  it "test mean works" $ do
+    withinPercent (mean [1,2,3]) 2 1e-3 `shouldBe` True
+    withinPercent (mean [1..100]) 50.5 1e-3 `shouldBe` True
+    withinPercent (mean [1..1000000]) 500000.5 1e-3 `shouldBe` True
+  it "test variance works" $ do
+    withinPercent (variance [0,1]) 0.5 1e-3 `shouldBe` True
+    withinPercent (variance [1,1,1]) 0 1e-3 `shouldBe` True
+    withinPercent (variance [1..100]) 841.66666666 1e-3 `shouldBe` True
+  it "test stdErr works" $ do
+    withinPercent (stdErr [1..100]) 2.901149 1e-3 `shouldBe` True
+    withinPercent (stdErr [1..1000]) 9.133273 1e-3 `shouldBe` True
 
 main :: IO ()
 main = hspec $ do
-  describe "Prelude.head" $ do
-    it "returns the first element of a list" $ do
-      head [23 ..] `shouldBe` (23 :: Int)
+  testHelperFunctions


### PR DESCRIPTION
Implement some basic testing with `hspec` to demonstrate that the algorithm performs as expected on a toy problem. This required some statistical functions to be implemented to avoid pulling in another dependency (such as `statistics`.)

A new function `chain'` was added which gives the user the ability to store data in `chainTunables`, hopefully with lazy evaluation this will only be evaluated when necessary to avoid unnecessary computation. The existing `chain` function is left unchanged, but now is just a wrapper around `chain'`. There was a change to `metropolis` but since `chain` appears to be the workhorse of the package this doesn't seem to devastating.

Version bump because the API was slightly altered and including testing means that an additional dependency was included.